### PR TITLE
Fix get_bgp_config multipath, local-as and VPRN neighbors

### DIFF
--- a/napalm_sros/nc_filters.py
+++ b/napalm_sros/nc_filters.py
@@ -417,17 +417,15 @@ GET_BGP_CONFIG = {
                     <local-as>
                         <as-number/>
                     </local-as>
-                    <import>
-                        <policy/>
-                    </import>
-                    <export>
-                        <policy/>
-                    </export>
                     <remove-private/>
                     <cluster>
                         <cluster-id/>
                     </cluster>
-
+                    <multipath>
+                     <ebgp/>
+                     <ibgp/>
+                    </multipath>
+                    <client-reflect/>
                     <group>
                         <group-name>{group_name}</group-name>
                         <description/>
@@ -437,6 +435,7 @@ GET_BGP_CONFIG = {
                         <peer-as/>
                         <local-address/>
                         <next-hop-self/>
+                        <client-reflect/>
                         <local-as>
                             <as-number/>
                         </local-as>
@@ -449,7 +448,6 @@ GET_BGP_CONFIG = {
                         <remove-private>
                             <limited/>
                         </remove-private>
-                        <multipath-eligible/>
                         <prefix-limit>
                             <family/>
                             <maximum/>
@@ -461,6 +459,7 @@ GET_BGP_CONFIG = {
                     <neighbor>
                         <ip-address>{neighbor}</ip-address>
                         <group/>
+                        <type/>
                         <authentication-keychain/>
                         <description/>
                         <peer-as/>
@@ -490,25 +489,23 @@ GET_BGP_CONFIG = {
             </router>
             <service>
                 <vprn>
-                    <autonomous-system/>
-                    <bgp>
+                  <autonomous-system/>
+                  <bgp>
                     <description/>
                     <apply-groups/>
                     <multihop/>
                     <local-as>
                         <as-number/>
                     </local-as>
-                    <import>
-                        <policy/>
-                    </import>
-                    <export>
-                        <policy/>
-                    </export>
                     <remove-private/>
                     <cluster>
                         <cluster-id/>
                     </cluster>
-
+                    <multipath>
+                     <ebgp/>
+                     <ibgp/>
+                    </multipath>
+                    <client-reflect/>
                     <group>
                         <group-name>{group_name}</group-name>
                         <description/>
@@ -540,15 +537,17 @@ GET_BGP_CONFIG = {
                         <cluster>
                             <cluster-id/>
                         </cluster>
+                        <client-reflect/>
                     </group>
-
                     <neighbor>
                         <ip-address>{neighbor}</ip-address>
                         <group/>
+                        <type/>
                         <authentication-keychain/>
                         <description/>
                         <peer-as/>
                         <next-hop-self/>
+                        <client-reflect/>
                         <local-as>
                             <as-number/>
                         </local-as>
@@ -572,7 +571,7 @@ GET_BGP_CONFIG = {
                             <cluster-id/>
                         </cluster>
                     </neighbor>
-                </bgp>
+                  </bgp>
                 </vprn>
             </service>
         </configure>

--- a/napalm_sros/sros.py
+++ b/napalm_sros/sros.py
@@ -2617,6 +2617,10 @@ class NokiaSROSDriver(NetworkDriver):
                 }
             }
         """
+        #
+        # Note: returns all bgp neighbors across all VRFs, merging groups with the same name
+        # Does not (cannot) report dynamic neighbors, only static ones
+        #
         try:
             bgp_config = {}
 
@@ -2664,64 +2668,69 @@ class NokiaSROSDriver(NetworkDriver):
                 policies = [ele.text for ele in policies_xml]
                 return ", ".join(policies)
 
-            def _get_bgp_neighbor_group(bgp_neighbors, global_autonomous):
+            def _route_reflect(xml):
+              _cluster_id = self._find_txt(xml,"configure_ns:cluster/configure_ns:cluster-id",namespaces=self.nsmap)
+              _client_reflect = self._find_txt(xml,"configure_ns:client-reflect", namespaces=self.nsmap)
+              return (bool(_cluster_id),_client_reflect) # keep client_reflect as string to distinguish between not set and 'false'
+
+            def _get_bgp_neighbor_group(bgp_neighbors,global_autonomous):
                 for bgp_neighbor in bgp_neighbors:
                     group_name = self._find_txt(
                         bgp_neighbor, "configure_ns:group", namespaces=self.nsmap
                     )
+
+                    def _group_attr(attr):
+                      return bgp_groups[group_name][attr] if group_name in bgp_groups and attr in bgp_groups[group_name] else None
+
                     peer = ip(
                         self._find_txt(
                             bgp_neighbor, "configure_ns:ip-address", namespaces=self.nsmap
                         )
                     )
-                    type_ = self._find_txt(
-                        bgp_neighbor, "configure_ns:type", namespaces=self.nsmap
-                    )
 
                     if neighbor != "" and peer != neighbor:
                         continue
 
-                    nhs = (
-                        True
-                        if self._find_txt(
-                            bgp_neighbor,
-                            "configure_ns:next-hop-self",
-                            namespaces=self.nsmap,
-                        )
-                        == "true"
-                        else False
+                    # JvB note: 'type' configuration allows implicit peer AS configuration for iBGP
+                    type_ = self._find_txt(
+                        bgp_neighbor, "configure_ns:type", namespaces=self.nsmap
+                    ) or _group_attr('type')
+
+                    _nhs = self._find_txt(
+                        bgp_neighbor,"configure_ns:next-hop-self",namespaces=self.nsmap,
                     )
-                    cluster_id = self._find_txt(
-                        bgp_neighbor,
-                        "configure_ns:cluster/configure_ns:cluster-id",
-                        namespaces=self.nsmap,
-                    )
-                    client_reflect = self._find_txt(
-                        bgp_neighbor, "configure_ns:client-reflect", namespaces=self.nsmap
-                    )
-                    route_reflector = ""
-                    if cluster_id and client_reflect == "true":
-                        route_reflector = True
+                    _next_hop_self = (_nhs != "false") if _nhs else _group_attr('_nhs')
+
+                    _cluster_id,_client_reflect = _route_reflect(bgp_neighbor)
+                    route_reflector = (_cluster_id or _group_attr('_cluster_id')) \
+                                  and (_group_attr('_client_reflect') and _client_reflect=="")
 
                     explicit_local_as = self._find_txt(
                         bgp_neighbor,
                         "configure_ns:local-as/configure_ns:as-number",
                         namespaces=self.nsmap,
                     )
-                    if explicit_local_as:
-                        local_as = explicit_local_as
-                    else:
-                        local_as = global_autonomous
+
+                    # Order of priority:
+                    # 1. Neighbor level local-as
+                    # 2. Group level local-as
+                    # 3. Global AS
+                    local_as = explicit_local_as or _group_attr('local_as') or global_autonomous
 
                     explicit_peer_as = self._find_txt(
                         bgp_neighbor, "configure_ns:peer-as", namespaces=self.nsmap
                     )
+
                     if explicit_peer_as:
-                        peer_as = explicit_peer_as
-                    elif type_ == "internal" and not explicit_peer_as:
-                        peer_as = global_autonomous
+                      peer_as = explicit_peer_as
                     else:
-                        peer_as = 0
+                      group_remote_as = _group_attr('remote_as')
+                      if group_remote_as:
+                        peer_as = group_remote_as
+                      elif type_=="internal": # implicit peer_as configuration
+                        peer_as = local_as
+                      else:
+                        peer_as = 0 # Not configured
 
                     if group_name not in bgp_group_neighbors.keys():
                         bgp_group_neighbors[group_name] = {}
@@ -2729,6 +2738,7 @@ class NokiaSROSDriver(NetworkDriver):
                         "description": self._find_txt(
                             bgp_neighbor, "configure_ns:description", namespaces=self.nsmap
                         ),
+                        "local_as": as_number(local_as),
                         "remote_as": as_number(peer_as),
                         "prefix_limit": _build_prefix_limit(bgp_neighbor),
                         "import_policy": _get_policies(
@@ -2751,29 +2761,25 @@ class NokiaSROSDriver(NetworkDriver):
                                 namespaces=self.nsmap,
                             ),
                         ),
-                        "local_as": as_number(local_as),
+                        # Note: ignoring any group level authentication key here
                         "authentication_key": self._find_txt(
                             bgp_neighbor,
                             "configure_ns:authentication-key",
                             namespaces=self.nsmap,
                         ),
-                        "nhs": nhs,
+                        "nhs": bool(_next_hop_self),
                         "route_reflector_client": route_reflector,
                     }
                     if neighbor != "" and peer == neighbor:
                         break
 
-            def _get_bgp_group_data(bgp_groups_list):
+            def _get_bgp_group_data(bgp_groups_list,local_as_number,g_cluster_id,g_client_reflect):
                 for bgp_group in bgp_groups_list:
                     group_name = self._find_txt(
                         bgp_group, "configure_ns:group-name", namespaces=self.nsmap
                     )
                     if group != "" and group != group_name:
                         continue
-
-                    type_ = self._find_txt(
-                        bgp_group, "configure_ns:type", namespaces=self.nsmap
-                    )
 
                     remove_private = (
                         True
@@ -2785,58 +2791,39 @@ class NokiaSROSDriver(NetworkDriver):
                         == "true"
                         else False
                     )
-                    multipath = (
-                        True
-                        if self._find_txt(
-                            bgp_group,
-                            "configure_ns:multipath-eligible",
-                            namespaces=self.nsmap,
-                        )
-                        == "true"
-                        else False
+                    type_ = self._find_txt(
+                        bgp_group, "configure_ns:type", namespaces=self.nsmap
                     )
-
                     explicit_local_as = self._find_txt(
                         bgp_group,
                         "configure_ns:local-as/configure_ns:as-number",
                         namespaces=self.nsmap,
                     )
-                    if explicit_local_as:
-                        local_as = explicit_local_as
-                    else:
-                        local_as = global_as
+                    local_as = int(explicit_local_as or local_as_number)
 
                     explicit_peer_as = self._find_txt(
                         bgp_group, "configure_ns:peer-as", namespaces=self.nsmap
                     )
                     if explicit_peer_as:
-                        peer_as = explicit_peer_as
-                    elif type_ == "internal" and not explicit_peer_as:
-                        peer_as = global_as
-                    elif type_ == "internal" and explicit_local_as:
-                        peer_as = explicit_local_as
+                      peer_as = int(explicit_peer_as)
+                      type_ = "internal" if peer_as==local_as else "external"
+                    elif type_=="internal":
+                      peer_as = local_as # Implicitly configured
                     else:
-                        peer_as = 0
+                      peer_as = 0 # Not configured, type_ may be 'no-type'
 
-                    nhs = (
-                        True
-                        if self._find_txt(
-                            bgp_group, "configure_ns:next-hop-self", namespaces=self.nsmap
-                        )
-                        == "true"
-                        else False
-                    )
-                    cluster_id = self._find_txt(
+                    xbgp = "ibgp" if type_=="internal" else "ebgp"
+                    max_path = self._find_txt(
                         bgp_group,
-                        "configure_ns:cluster/configure_ns:cluster-id",
+                        f"../configure_ns:multipath/configure_ns:{xbgp}",
                         namespaces=self.nsmap,
                     )
-                    client_reflect = self._find_txt(
-                        bgp_group, "configure_ns:client-reflect", namespaces=self.nsmap
-                    )
-                    route_reflector = False
-                    if cluster_id and client_reflect == "true":
-                        route_reflector = True
+                    multipath = bool( peer_as and max_path and int(max_path)>1 )
+
+                    _nhs = self._find_txt(bgp_group, "configure_ns:next-hop-self", namespaces=self.nsmap)
+                    # Can only set client_reflect to 'false' at group level
+                    _cluster_id,_client_reflect = _route_reflect(bgp_group)
+
                     apply_groups_list = []
                     for apply_group in bgp_group.xpath(
                         "configure_ns:apply-groups", namespaces=self.nsmap
@@ -2844,12 +2831,14 @@ class NokiaSROSDriver(NetworkDriver):
                         apply_groups_list.append(apply_group)
 
                     bgp_groups[group_name] = {
-                        "apply_groups": apply_groups_list,
+                        "type": type_,
                         "description": self._find_txt(
                             bgp_group, "configure_ns:description", namespaces=self.nsmap
                         ),
+                        "apply_groups": apply_groups_list,
                         "local_as": as_number(local_as),
-                        "type": type_,
+                        "remote_as": as_number(peer_as),
+                        "remove_private_as": remove_private,
                         "import_policy": _get_policies(
                             bgp_group.xpath(
                                 "configure_ns:import/configure_ns:policy",
@@ -2878,11 +2867,10 @@ class NokiaSROSDriver(NetworkDriver):
                             ),
                             default=-1,
                         ),
-                        "remote_as": as_number(peer_as),
-                        "remove_private_as": remove_private,
                         "prefix_limit": _build_prefix_limit(bgp_group),
-                        "_nhs": nhs,
-                        "_route_reflector_client": route_reflector,
+                        "_nhs": bool(_nhs != "false"),
+                        "_cluster_id": g_cluster_id or bool(_cluster_id),
+                        "_client_reflect": g_client_reflect and _client_reflect=="",
                         "neighbors": {},
                     }
                     if group != "" and group == group_name:
@@ -2894,7 +2882,7 @@ class NokiaSROSDriver(NetworkDriver):
                     with_defaults="report-all",
                 ).data_xml
             )
-            bgp_config["debug"] = to_xml(bgp_running_config, pretty_print=True)
+            print( to_xml(bgp_running_config, pretty_print=True) )
 
             bgp_group_neighbors = {}
             bgp_groups = {}
@@ -2908,8 +2896,11 @@ class NokiaSROSDriver(NetworkDriver):
                 "configure_ns:configure/configure_ns:router/configure_ns:bgp",
                 namespaces=self.nsmap,
             ):
+                _cluster_id,_client_reflect = _route_reflect(router)
                 _get_bgp_group_data(
-                    router.xpath("configure_ns:group", namespaces=self.nsmap)
+                    router.xpath("configure_ns:group", namespaces=self.nsmap),
+                    local_as_number=int(global_as),
+                    g_cluster_id=_cluster_id,g_client_reflect=_client_reflect
                 )
                 _get_bgp_neighbor_group(
                     router.xpath("configure_ns:neighbor", namespaces=self.nsmap),
@@ -2924,34 +2915,24 @@ class NokiaSROSDriver(NetworkDriver):
                     vprn,"../configure_ns:autonomous-system",
                     namespaces=self.nsmap,
                 )
-                print( f"JvB: vprn_as={vprn_as}" )
+                _cluster_id,_client_reflect = _route_reflect(vprn)
                 _get_bgp_group_data(
-                    vprn.xpath("configure_ns:group", namespaces=self.nsmap)
+                    vprn.xpath("configure_ns:group", namespaces=self.nsmap),
+                    local_as_number=int(vprn_as),
+                    g_cluster_id=_cluster_id,g_client_reflect=_client_reflect
                 )
                 _get_bgp_neighbor_group(
-                    vprn.xpath("neighbor", namespaces=self.nsmap),
-                    vprn_as
+                    vprn.xpath("configure_ns:neighbor",namespaces=self.nsmap),
+                    vprn_as,
                 )
 
             # Assemble groups and neighbors
             for grp_name, grp_data in bgp_groups.items():
                 neighbors = bgp_group_neighbors.get(grp_name, {})
 
-                # Update values from group level
-                for n_data in neighbors.values():
-                    # Update NHS from group level
-                    if not n_data.get("nhs"):
-                        n_data["nhs"] = grp_data.get("_nhs")
-                    # Update remote-as to local-as when group is internal
-                    if grp_data.get("type") == "internal":
-                        n_data["remote_as"] = n_data.get("local_as")
-                    # Update route_reflector_client from group_level
-                    if not n_data.get("route_reflector_client"):
-                        n_data["route_reflector_client"] = grp_data.get(
-                            "_route_reflector_client"
-                        )
-                grp_data.pop("_nhs")  # remove temporary key
-                grp_data.pop("_route_reflector_client")  # remove temporary key
+                grp_data.pop("_nhs")  # remove temporary keys
+                grp_data.pop("_cluster_id")
+                grp_data.pop("_client_reflect")
 
                 grp_data["neighbors"] = neighbors  # Add updated neighbors to group
 

--- a/test/unit/mocked_data/test_get_bgp_config/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_bgp_config/normal/expected_result.json
@@ -1,58 +1,141 @@
 {
-    "eBGP-Peers": {
-        "apply_groups": [],
+  "ebgp": {
+    "type": "external",
+    "description": "",
+    "apply_groups": [],
+    "local_as": 65000,
+    "remote_as": 65001,
+    "remove_private_as": false,
+    "import_policy": "",
+    "export_policy": "",
+    "local_address": "",
+    "multipath": true,
+    "multihop_ttl": -1,
+    "prefix_limit": {},
+    "neighbors": {
+      "192.0.0.1": {
         "description": "",
         "local_as": 65000,
-        "type": "external",
-        "import_policy": "eBGP-import",
+        "remote_as": 65001,
+        "prefix_limit": {},
+        "import_policy": "",
         "export_policy": "",
         "local_address": "",
-        "multipath": false,
-        "multihop_ttl": -1,
-        "remote_as": 0,
-        "remove_private_as": false,
-        "prefix_limit": {},
-        "neighbors": {
-            "1.1.0.1": {
-              "description": "",
-              "remote_as": 65101,
-              "prefix_limit": {},
-              "import_policy": "",
-              "export_policy": "",
-              "local_address": "",
-              "local_as": 65000,
-              "authentication_key": "",
-              "nhs": false,
-              "route_reflector_client": false
-            }
-        }
-    },
-    "iBGP-Peers": {
-        "apply_groups": [],
+        "authentication_key": "",
+        "nhs": false,
+        "route_reflector_client": false
+      },
+      "192.0.0.3": {
         "description": "",
         "local_as": 65000,
-        "type": "internal",
-        "import_policy": "add-comm-ibgp",
+        "remote_as": 65002,
+        "prefix_limit": {},
+        "import_policy": "",
         "export_policy": "",
         "local_address": "",
-        "multipath": false,
-        "multihop_ttl": -1,
-        "remote_as": 65000,
-        "remove_private_as": false,
-        "prefix_limit": {},
-        "neighbors": {
-            "2.1.0.1": {
-                "description": "",
-                "remote_as": 65000,
-                "prefix_limit": {},
-                "import_policy": "",
-                "export_policy": "",
-                "local_address": "",
-                "local_as": 65000,
-                "authentication_key": "",
-                "nhs": false,
-                "route_reflector_client": false
-            }
-        }
+        "authentication_key": "",
+        "nhs": false,
+        "route_reflector_client": false
+      }
     }
+  },
+  "ibgp": {
+    "type": "external",
+    "description": "",
+    "apply_groups": [],
+    "local_as": 65123,
+    "remote_as": 0,
+    "remove_private_as": false,
+    "import_policy": "",
+    "export_policy": "",
+    "local_address": "",
+    "multipath": false,
+    "multihop_ttl": -1,
+    "prefix_limit": {},
+    "neighbors": {
+      "2001:192::2": {
+        "description": "",
+        "local_as": 65123,
+        "remote_as": 65123,
+        "prefix_limit": {},
+        "import_policy": "",
+        "export_policy": "",
+        "local_address": "",
+        "authentication_key": "",
+        "nhs": false,
+        "route_reflector_client": false
+      }
+    }
+  },
+  "ebgp-vprn": {
+    "type": "external",
+    "description": "",
+    "apply_groups": [],
+    "local_as": 65001,
+    "remote_as": 65000,
+    "remove_private_as": false,
+    "import_policy": "",
+    "export_policy": "",
+    "local_address": "",
+    "multipath": false,
+    "multihop_ttl": -1,
+    "prefix_limit": {},
+    "neighbors": {
+      "192.0.0.0": {
+        "description": "",
+        "local_as": 65001,
+        "remote_as": 65000,
+        "prefix_limit": {},
+        "import_policy": "",
+        "export_policy": "",
+        "local_address": "",
+        "authentication_key": "",
+        "nhs": false,
+        "route_reflector_client": false
+      }
+    }
+  },
+  "ibgp-vprn": {
+    "type": "external",
+    "description": "",
+    "apply_groups": [],
+    "local_as": 65001,
+    "remote_as": 65123,
+    "remove_private_as": false,
+    "import_policy": "",
+    "export_policy": "",
+    "local_address": "",
+    "multipath": false,
+    "multihop_ttl": -1,
+    "prefix_limit": {},
+    "neighbors": {
+      "2001:192::1": {
+        "description": "",
+        "local_as": 65123,
+        "remote_as": 65123,
+        "prefix_limit": {},
+        "import_policy": "",
+        "export_policy": "",
+        "local_address": "",
+        "authentication_key": "",
+        "nhs": true,
+        "route_reflector_client": false
+      }
+    }
+  },
+  "ebgp-vprn2": {
+    "type": "no-type",
+    "description": "",
+    "apply_groups": [],
+    "local_as": 65002,
+    "remote_as": 0,
+    "remove_private_as": true,
+    "import_policy": "",
+    "export_policy": "reject_all",
+    "local_address": "192.0.0.3",
+    "multipath": false,
+    "multihop_ttl": -1,
+    "prefix_limit": {},
+    "neighbors": {}
+  }
 }

--- a/test/unit/mocked_data/test_get_bgp_config/normal/get_bgp_config.xml
+++ b/test/unit/mocked_data/test_get_bgp_config/normal/get_bgp_config.xml
@@ -1,36 +1,164 @@
-<data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
-    <configure xmlns="urn:nokia.com:sros:ns:yang:sr:conf">
+<?xml version="1.0" encoding="UTF-8"?><data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <configure xmlns="urn:nokia.com:sros:ns:yang:sr:conf" xmlns:nokia-attr="urn:nokia.com:sros:ns:yang:sr:attributes">
         <router>
             <router-name>Base</router-name>
             <autonomous-system>65000</autonomous-system>
             <bgp>
+                <client-reflect>true</client-reflect>
+                <cluster>
+                </cluster>
+                <local-as>
+                </local-as>
+                <import>
+                    <policy>accept_all</policy>
+                </import>
+                <multipath>
+                    <ebgp>2</ebgp>
+                </multipath>
                 <group>
-                    <group-name>eBGP-Peers</group-name>
-                    <type>external</type>
-                    <import>
-                        <policy>eBGP-import</policy>
-                    </import>
+                    <group-name>ebgp</group-name>
+                    <next-hop-self>false</next-hop-self>
+                    <type>internal</type>
+                    <peer-as>65001</peer-as>
+                    <local-as>
+                    </local-as>
                 </group>
                 <group>
-                    <group-name>iBGP-Peers</group-name>
-                    <type>internal</type>
-                    <cluster>
-                        <cluster-id>10.1.1.1</cluster-id>
-                    </cluster>
-                    <import>
-                        <policy>add-comm-ibgp</policy>
-                    </import>
+                    <group-name>ibgp</group-name>
+                    <next-hop-self>false</next-hop-self>
+                    <type>external</type>
+                    <local-as>
+                        <as-number>65123</as-number>
+                    </local-as>
                 </group>
                 <neighbor>
-                    <ip-address>1.1.0.1</ip-address>
-                    <group>eBGP-Peers</group>
-                    <peer-as>65101</peer-as>
+                    <ip-address>192.0.0.1</ip-address>
+                    <group>ebgp</group>
+                    <cluster>
+                    </cluster>
+                    <local-as>
+                    </local-as>
                 </neighbor>
                 <neighbor>
-                    <ip-address>2.1.0.1</ip-address>
-                    <group>iBGP-Peers</group>
+                    <ip-address>192.0.0.3</ip-address>
+                    <group>ebgp</group>
+                    <peer-as>65002</peer-as>
+                    <cluster>
+                    </cluster>
+                    <local-as>
+                    </local-as>
+                </neighbor>
+                <neighbor>
+                    <ip-address>2001:192::2</ip-address>
+                    <group>ibgp</group>
+                    <type>internal</type>
+                    <cluster>
+                    </cluster>
+                    <local-as>
+                    </local-as>
                 </neighbor>
             </bgp>
         </router>
+        <router>
+            <router-name>management</router-name>
+        </router>
+        <router>
+            <router-name>vpls-management</router-name>
+        </router>
+        <service>
+            <vprn>
+                <service-name>peer</service-name>
+                <autonomous-system>65001</autonomous-system>
+                <bgp>
+                    <client-reflect>true</client-reflect>
+                    <cluster>
+                    </cluster>
+                    <local-as>
+                    </local-as>
+                    <import>
+                        <policy>accept_all</policy>
+                    </import>
+                    <export>
+                        <policy>accept_all</policy>
+                    </export>
+                    <multipath>
+                    </multipath>
+                    <group>
+                        <group-name>ebgp-vprn</group-name>
+                        <next-hop-self>false</next-hop-self>
+                        <type>no-type</type>
+                        <peer-as>65000</peer-as>
+                        <cluster>
+                        </cluster>
+                        <local-as>
+                        </local-as>
+                    </group>
+                    <group>
+                        <group-name>ibgp-vprn</group-name>
+                        <next-hop-self>true</next-hop-self>
+                        <type>no-type</type>
+                        <peer-as>65123</peer-as>
+                        <cluster>
+                        </cluster>
+                        <local-as>
+                        </local-as>
+                    </group>
+                    <neighbor>
+                        <ip-address>192.0.0.0</ip-address>
+                        <group>ebgp-vprn</group>
+                        <cluster>
+                        </cluster>
+                        <local-as>
+                        </local-as>
+                    </neighbor>
+                    <neighbor>
+                        <ip-address>2001:192::1</ip-address>
+                        <group>ibgp-vprn</group>
+                        <client-reflect>false</client-reflect>
+                        <cluster>
+                            <cluster-id>1.2.3.4</cluster-id>
+                        </cluster>
+                        <local-as>
+                            <as-number>65123</as-number>
+                        </local-as>
+                    </neighbor>
+                </bgp>
+            </vprn>
+            <vprn>
+                <service-name>peer2</service-name>
+                <autonomous-system>65002</autonomous-system>
+                <bgp>
+                    <client-reflect>true</client-reflect>
+                    <cluster>
+                    </cluster>
+                    <local-as>
+                    </local-as>
+                    <export>
+                        <policy>accept_all</policy>
+                    </export>
+                    <multipath>
+                    </multipath>
+                    <group>
+                        <group-name>ebgp-vprn2</group-name>
+                        <next-hop-self>false</next-hop-self>
+                        <type>no-type</type>
+                        <local-address>192.0.0.3</local-address>
+                        <remove-private>
+                            <limited>true</limited>
+                            <skip-peer-as>false</skip-peer-as>
+                            <replace>false</replace>
+                        </remove-private>
+                        <cluster>
+                        </cluster>
+                        <local-as>
+                            <as-number>65002</as-number>
+                        </local-as>
+                        <export>
+                            <policy>reject_all</policy>
+                        </export>
+                    </group>
+                </bgp>
+            </vprn>
+        </service>
     </configure>
 </data>


### PR DESCRIPTION
* properly include vprn neighbors
* use correct autonomous-system within vprns, not global value
* multipath setting depends on 'multipath' (ebgp/ibgp), not 'multipath-eligible'
* neighbor can be found without specifying the group (like on ios), no need to forbid it (like junos driver)
* fix local-as logic when type is set to 'internal'
* route_reflector_client: take hierarchy into account, i.e. group and global level cluster-id and client-reflect settings