### PR TITLE
Update 'cli' method to accept an encoding parameter (introduced in napalm 4.0.0)

### DIFF
--- a/napalm_sros/sros.py
+++ b/napalm_sros/sros.py
@@ -3544,10 +3544,12 @@ class NokiaSROSDriver(NetworkDriver):
             print("Error in method traceroute : {}".format(e))
             log.error("Error in method traceroute : %s" % traceback.format_exc())
 
-    def cli(self, commands):
+    def cli(self, commands, encoding="text"):
         """
         Will execute a list of commands and return the output in a dictionary format.
         """
+        if encoding not in ("text",):
+            raise NotImplementedError("%s is not a supported encoding" % encoding)
         try:
             cli_output = {}
             for cmd in commands:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-napalm>=3.4.1
+napalm>=4.0.0
 pytest>=7.0.1
 setuptools>=47.3.1
 pip>=21.3.1
-textfsm>=1.1.3
+textfsm>=1.1.2
 paramiko>=2.11.0
 lxml>=4.9.1
 ncclient>=0.6.13

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ setup(
     url="https://github.com/napalm-automation/napalm-sros",
     include_package_data=True,
     install_requires=[
-        "napalm>=3.4.1",
+        "napalm>=4.0.0",
         "pytest>=7.0.1",
-        "textfsm>=1.1.3",
+        "textfsm>=1.1.2",
         "paramiko>=2.11.0",
         "lxml>=4.9.1",
         "ncclient>=0.6.13",


### PR DESCRIPTION
Only 'text' (default value) is accepted, anything else throws an error (just like most other plugins)