### PR TITLE
Add sfm in temperature report, rename location to cpm-A, card-1, etc.

### DIFF
--- a/napalm_sros/nc_filters.py
+++ b/napalm_sros/nc_filters.py
@@ -647,8 +647,71 @@ GET_IPV6_NEIGHBORS_TABLE = {
     """
 }
 
-
 GET_ENVIRONMENT = {
+    "_": """
+    <filter>
+        <state xmlns="urn:nokia.com:sros:ns:yang:sr:state">
+            <chassis>
+            <fan>
+                <fan-slot/>
+                <hardware-data>
+                    <oper-state/>
+                </hardware-data>
+            </fan>
+            <power-supply>
+             <first-power-supply-status/>
+            </power-supply>
+            </chassis>
+            <cpm>
+                <hardware-data>
+                    <contains-temperature-sensor>true</contains-temperature-sensor>
+                    <temperature/>
+                    <temperature-threshold/>
+                </hardware-data>
+            </cpm>
+            <sfm>
+                <hardware-data>
+                    <contains-temperature-sensor>true</contains-temperature-sensor>
+                    <temperature/>
+                    <temperature-threshold/>
+                </hardware-data>
+            </sfm>
+            <card>
+                <hardware-data>
+                    <contains-temperature-sensor>true</contains-temperature-sensor>
+                    <temperature/>
+                    <temperature-threshold/>
+                </hardware-data>
+                <mda>
+                    <hardware-data>
+                        <contains-temperature-sensor>true</contains-temperature-sensor>
+                        <temperature/>
+                        <temperature-threshold/>
+                    </hardware-data>
+                </mda>
+            </card>
+            <system>
+                <memory-pools>
+                    <summary>
+                        <available-memory/>
+                        <total-in-use/>
+                    </summary>
+                </memory-pools>
+                <cpu>
+                    <summary>
+                        <usage>
+                            <cpu-usage/>
+                        </usage>
+                    </summary>
+                </cpu>
+            </system>
+        </state>
+    </filter>
+    """
+}
+
+# Issue: 'power-shelf' not available in VSR 21.10.R1
+GET_ENVIRONMENT_ORIG = {
     "_": """
     <filter>
         <state xmlns="urn:nokia.com:sros:ns:yang:sr:state">

--- a/test/unit/mocked_data/test_get_environment/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_environment/normal/expected_result.json
@@ -25,17 +25,17 @@
         }
     },
     "temperature": {
-        "cpm": {
+        "cpm-A": {
             "temperature": 62.0,
             "is_alert": false,
             "is_critical": false
         },
-        "card": {
+        "card-1": {
             "temperature": 62.0,
             "is_alert": false,
             "is_critical": false
         },
-        "mda": {
+        "mda-1": {
             "temperature": 49.0,
             "is_alert": false,
             "is_critical": false


### PR DESCRIPTION
The current version reports at most 3 temperature values:
* 1xcpm
* 1xcard
* 1xmda

However, 7x50 devices may have several of each of those elements, and all report their temperature levels.
Note that the method used to collect power usage per module does not work on recent SR OS versions